### PR TITLE
Astro Config angepasst

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -16,6 +16,9 @@ const GIT_COMMIT_HASH = (() => {
 
 export default defineConfig({
   site: "https://falkner.info",
+  markdown: {
+    syntaxHighlight: false,
+  },
   security: {
     csp: {
       directives: [


### PR DESCRIPTION
In astro.config.mjs (line 19) ist nun markdown.syntaxHighlight: false gesetzt. Da aktuell keine Markdown-Codeblöcke verwendet werden, ändert das die sichtbare Website nicht und entfernt die unpassende Shiki/CSP-Warnung.